### PR TITLE
move packing to the publish workflow

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -3,7 +3,7 @@ on:
     branches:
       - main
 
-name: Package VSCode Extension
+name: Validate VSCode Extension
 jobs:
   package:
     runs-on: ubuntu-latest
@@ -13,12 +13,5 @@ jobs:
         with:
           node-version: 23
       - run: npm ci
-      - name: Validate Extension
+      - name: Pre-publish
         run: npm run vscode:prepublish
-      - name: Package Extension
-        run: npx vsce package --no-dependencies
-      - name: Upload Package Artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: vscode-pwl
-          path: "*.vsix"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,10 +12,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 23
-      - name: Download Package Artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: vscode-pwl
+      - name: Package Extension
+        run: npx vsce package --no-dependencies
       - name: Create Git Tag
         id: tag
         run: |


### PR DESCRIPTION
I'm moving the package step to the publish workflow. The PR is still gated by the `prepublish` step which lints. Then once the PR is merged, it packages the extension and publishes it.